### PR TITLE
Remove Temporary Require Statements

### DIFF
--- a/app/controllers/api/v1/forecasts_controller.rb
+++ b/app/controllers/api/v1/forecasts_controller.rb
@@ -1,6 +1,3 @@
-require_relative '../../../services/map_service'
-require_relative '../../../services/weather_service'
-
 class Api::V1::ForecastsController < ApplicationController
   before_action :validate_params
 

--- a/app/controllers/api/v1/road_trips_controller.rb
+++ b/app/controllers/api/v1/road_trips_controller.rb
@@ -1,5 +1,3 @@
-require_relative '../../../facades/road_trip_facade'
-
 class Api::V1::RoadTripsController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :validate_params_exist

--- a/app/facades/road_trip_facade.rb
+++ b/app/facades/road_trip_facade.rb
@@ -1,6 +1,3 @@
-require_relative '../services/map_service'
-require_relative '../services/weather_service'
-
 class RoadTripFacade
   def self.create_trip(origin, destination)
     directions = fetch_directions(origin, destination)

--- a/spec/facades/road_trip_facade_spec.rb
+++ b/spec/facades/road_trip_facade_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../app/facades/road_trip_facade'
 require 'rails_helper'
 
 RSpec.describe 'Road Trip Facade' do

--- a/spec/services/map_service_spec.rb
+++ b/spec/services/map_service_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../../app/services/map_service.rb'
-
 require 'rails_helper'
 
 RSpec.describe 'Forecast Service' do

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../app/services/weather_service.rb'
 require 'rails_helper'
 
 RSpec.describe 'Weather Service' do


### PR DESCRIPTION
Remove `require_relative` calls made across the app when `vim-test` wasn't running tests correctly.
  - Spring had been running and it had an old version of the app loaded, I guess. Thus, it couldn't find the facade & service objects I was adding...